### PR TITLE
Fix website link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -44,7 +44,7 @@ export default function Home({ imgUrl, pexUrl, ptgUrl, ptgNm }) {
           </div>
         </div>
         <div className="footer">
-          <a className="monty" href="https://monty.ga">Made by Monty</a>
+          <a className="monty" href="https://www.ashmonty.com/">Made by Monty</a>
         </div>
       </section>
     </home>


### PR DESCRIPTION
At the bottom of the page, it said "Made by Monty" with a link to `monty.ga`, which is not a thing anymore. Thus, I have updated it with the new site, `https://www.ashmonty.com/`